### PR TITLE
Fix toggleable component recognition on admin form.

### DIFF
--- a/registry.admin.inc
+++ b/registry.admin.inc
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\registry\ConfigurableComponentInterface;
+use Drupal\registry\ToggleableComponentInterface;
 
 /**
  * Dashboard form for registered components.
@@ -14,6 +15,8 @@ function registry_admin_form($form, &$form_state) {
   foreach($components as $component_name => $info) {
     $component = new $info['class']();
     $details   = sprintf('%s (%s)', $info['name'], $component_name);
+
+    $form[$component_name]['#tree'] = TRUE;
 
     if (registry_get_disabled_modules($component)) {
       $has_disabled = TRUE;


### PR DESCRIPTION
This fixes the admin form's recognition and handling of toggleable components. Without it, all toggleable components are treated as non-toggleable components, and toggleable components (with the first part fixed) are not enabled/disabled correctly upon form submit.
