### PR TITLE
Add URL registry component

### DIFF
--- a/registry.admin.inc
+++ b/registry.admin.inc
@@ -2,6 +2,7 @@
 
 use Drupal\registry\ConfigurableComponentInterface;
 use Drupal\registry\ToggleableComponentInterface;
+use Drupal\registry\UrlComponentInterface;
 
 /**
  * Dashboard form for registered components.
@@ -31,7 +32,7 @@ function registry_admin_form($form, &$form_state) {
       '#markup' => $details,
     ];
     $form[$component_name]['url'] = [
-      '#markup' => $component->getUrl(),
+      '#markup' => $component instanceof UrlComponentInterface ? $component->getUrl() : t('N/A'),
     ];
 
     if ($component instanceof ToggleableComponentInterface) {

--- a/src/UrlComponentInterface.php
+++ b/src/UrlComponentInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\registry;
+
+
+/**
+ * The interface for registered components that have a service URL.
+ *
+ */
+interface UrlComponentInterface extends ComponentInterface {
+
+  /**
+   * Returns the URL to the component's underlying service.
+   *
+   * @return string
+   *
+   */
+  public function getUrl();
+
+}


### PR DESCRIPTION
This adds a URL registry component and fixes a bug where `registry_admin_form()` incorrectly assumed that all registry components have URLs.
