### PR TITLE
Split isProduction() into its own interface

### DIFF
--- a/registry.admin.inc
+++ b/registry.admin.inc
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\registry\ConfigurableComponentInterface;
+use Drupal\registry\ProductionComponentInterface;
 use Drupal\registry\ToggleableComponentInterface;
 use Drupal\registry\UrlComponentInterface;
 
@@ -52,7 +53,7 @@ function registry_admin_form($form, &$form_state) {
     }
 
     $form[$component_name]['production'] = [
-      '#markup' => $component->isProduction() ? t('Yes') : t('No'),
+      '#markup' => $component instanceof ProductionComponentInterface ? ($component->isProduction() ? t('Yes') : t('No')) : t('N/A'),
     ];
     $form[$component_name]['links'] = [
       '#markup' => $component instanceof ConfigurableComponentInterface ? l(t('Configure'), $component->getConfigUrl()) : '',

--- a/registry.drush.inc
+++ b/registry.drush.inc
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\registry\ProductionComponentInterface;
 use Drupal\registry\ToggleableComponentInterface;
 use Drupal\registry\UrlComponentInterface;
 
@@ -60,9 +61,9 @@ function registry_drush_list() {
     $component = new $info['class']();
     $rows[]    = [
       sprintf('%s (%s)', $info['name'], $key),
-      ($component instanceof UrlComponentInterface) ? $component->getUrl() : t('n/a'),
+      ($component instanceof UrlComponentInterface) ? $component->getUrl() : dt('n/a'),
       !($component instanceof ToggleableComponentInterface) || $component->isEnabled() ? dt('Yes') : dt('No'),
-      $component->isProduction() ? dt('Yes') : dt('No'),
+      ($component instanceof ProductionComponentInterface) ? ($component->isProduction() ? dt('Yes') : dt('No')) : dt('n/a'),
     ];
   }
 
@@ -111,15 +112,15 @@ function registry_drush_filter($production = true) {
   foreach($components as $key => $info) {
     $component = new $info['class']();
 
-    if ($production ^ $component->isProduction()) {
+    if ($component instanceof ProductionComponentInterface && $production ^ $component->isProduction()) {
       continue;
     }
 
     $rows[] = [
       sprintf('%s (%s)', $info['name'], $key),
-      ($component instanceof UrlComponentInterface) ? $component->getUrl() : t('n/a'),
+      ($component instanceof UrlComponentInterface) ? $component->getUrl() : dt('n/a'),
       !($component instanceof ToggleableComponentInterface) || $component->isEnabled() ? dt('Yes') : dt('No'),
-      $component->isProduction() ? dt('Yes') : dt('No'),
+      ($component instanceof ProductionComponentInterface) ? ($component->isProduction() ? dt('Yes') : dt('No')) : dt('n/a'),
     ];
     $count++;
   }

--- a/src/ComponentInterface.php
+++ b/src/ComponentInterface.php
@@ -10,15 +10,6 @@ namespace Drupal\registry;
 interface ComponentInterface {
 
   /**
-   * Determines if the component's configuration is considered "production
-   * mode".
-   *
-   * @return boolean
-   *
-   */
-  public function isProduction();
-
-  /**
    * Returns a list of modules that this component represents.
    *
    * @return array

--- a/src/ProductionComponentInterface.php
+++ b/src/ProductionComponentInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\registry;
+
+
+/**
+ * The interface for registered components that can have a "production mode".
+ *
+ */
+interface ProductionComponentInterface extends ComponentInterface {
+
+  /**
+   * Determines if the component's is considered in "production mode".
+   *
+   * @return boolean
+   *
+   */
+  public function isProduction();
+}


### PR DESCRIPTION
Allows components that do not have production-specific configuration to be registered.
